### PR TITLE
Implement `handler.off`

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -47,13 +47,20 @@ define([
     // Get result from execution of `handler[CALLBACK]`
     var result = me[CALLBACK].apply(me[SCOPE], args);
 
-    // If there's a `me[LIMIT]` and `++me[COUNT]` is greater or equal to it ...
+    // If there's a `me[LIMIT]` and `++me[COUNT]` is greater or equal to it we should `.off` ourselves
     if (me.hasOwnProperty(LIMIT) && ++me[COUNT] >= me[LIMIT]) {
-      // ... `me[EMITTER].off` `me` (note that `me[CALLBACK]` and `me[SCOPE]` are used by `.off`)
-      me[EMITTER].off(me[TYPE], me);
+      me.off();
     }
 
     return result;
+  };
+
+  Handler.prototype.off = function () {
+    // Let `me` be `this`
+    var me = this;
+
+    // `me[EMITTER].off` `me` (note that `me[CALLBACK]` and `me[SCOPE]` are used by `.off`)
+    me[EMITTER].off(me[TYPE], me);
   };
 
   return Handler;

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -33,6 +33,17 @@ define([
       assert.same(handler2, handlers[1]);
     },
 
+    "handler.off forwards to emitter.off": function () {
+      var emitter = new Emitter();
+      var callback = this.spy();
+      var handler = emitter.on("test", callback);
+
+      handler.off();
+      emitter.emit("test", "test");
+
+      refute.called(callback);
+    },
+
     "emit" : function () {
       var emitter = new Emitter();
       var callback = this.spy();


### PR DESCRIPTION
Add `.off` method that will remove the handler from its emitter to the `Handler.prototype`
- closes mu-lib/mu-emitter#2
- closes mu-lib/mu-emitter#3
